### PR TITLE
Rubocop saves the file before correcting it and runs checks again

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand('ruby.rubocopAutocorrect', () => {
         const document = vscode.window.activeTextEditor.document;
-        rubocopAutocorrect.execute(document);
+        document.save().then(() => {
+            rubocopAutocorrect.execute(document)
+                .addListener('close', () => rubocop.execute(document));
+        });
     });
 
     context.subscriptions.push(disposable);

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 import { RubocopOutput, RubocopFile, RubocopOffense } from './rubocopOutput';
 import * as path from 'path';
 import * as fs from 'fs';
+import {ChildProcess} from 'child_process';
 
 interface RubocopConfig {
     executePath: string;
@@ -23,7 +24,7 @@ export class Rubocop {
         this.resetConfig();
     }
 
-    public execute(document: vscode.TextDocument): void {
+    public execute(document: vscode.TextDocument): ChildProcess {
         if (document.languageId !== 'ruby') {
             return;
         }
@@ -95,7 +96,7 @@ export class Rubocop {
         };
 
         let args = this.commandArguments(fileName);
-        cp.execFile(executeFile, args, { cwd: currentPath }, onDidExec);
+        return cp.execFile(executeFile, args, { cwd: currentPath }, onDidExec);
     }
 
     public get isOnSave(): boolean {


### PR DESCRIPTION
Without saving it will cause an issue that you have unsaved changes, but
file has already been updated in File System. Also, as it doesn't check
the file again, we force rubocop to run them.