### PR TITLE
Ensure file exists on disk before executing #36

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -25,7 +25,7 @@ export class Rubocop {
     }
 
     public execute(document: vscode.TextDocument): ChildProcess {
-        if (document.languageId !== 'ruby') {
+        if (document.languageId !== 'ruby' || document.isUntitled) {
             return;
         }
 


### PR DESCRIPTION
Don't execute on temporary files (i.e. git diff documents). Doing so results in annoying error messages when the file can not be found.