### PR TITLE
Do not run cops against ignored files

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -86,7 +86,7 @@ export class Rubocop {
 
     // extract argument to an array
     protected commandArguments(fileName: string): Array<string> {
-        let commandArguments = [fileName, '--format', 'json'];
+        let commandArguments = [fileName, '--format', 'json', '--force-exclusion'];
 
         if (this.configPath !== '') {
             if (fs.existsSync(this.configPath)) {


### PR DESCRIPTION
I've used Visual Studio Code since last summer and for the past few months, around the time I switched hardware, I've noticed my db/schema.rb file getting evaluated by the ruby-rubocop extension unnecessarily.

It's not ignored by the rubocop.yml file exclusion list either, and while when rubocop is run from the command line and on our CI we don't have issues with schema.rb, this has caused tension everytime I open the schema.rb and do database work. While I rarely have a need to keep that file open long-term, this fix definitely makes this extension less frustrating since I open this file near daily.

This PR fixes how ruby-rubocop chooses to evaluate files and display warnings/errors but using rubocop's --force-exclusion tag to force the ignoring of db/schema.rb.