### PR TITLE
Bundler Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.0
+- Automatically detect and use bundled rubocop
+
 # 0.4.0
 
 - Lint files opened before the extension is loaded.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/node": "^6.0.40",
     "chai": "^3.5.0",
     "mocha": "^3.3.0",
+    "proxyquire": "^1.8.0",
     "sinon": "^2.1.0",
     "tslint": "^5.1.0",
     "typescript": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruby-rubocop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "misogi",
   "displayName": "ruby-rubocop",
   "description": "execute rubocop for current Ruby code.",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,76 @@
+import * as vs from 'vscode';
+import * as fs from 'fs';
+import * as cp from 'child_process';
+import * as path from 'path';
+import Rubocop from './rubocop';
+
+export interface RubocopConfig {
+    command: string;
+    onSave: boolean;
+    configFilePath: string;
+    useBundler: boolean;
+}
+
+export const onDidChangeConfiguration: (rubocop: Rubocop) => () => void = (rubocop) => {
+    return () => rubocop.config = getConfig();
+};
+
+/**
+ * Read the workspace configuration for 'ruby.rubocop' and return a RubocopConfig.
+ * @return {RubocopConfig} config object
+ */
+export const getConfig: () => RubocopConfig = () => {
+    const win32 = process.platform === 'win32';
+    const cmd = win32 ? 'rubocop.bat' : 'rubocop';
+    const conf = vs.workspace.getConfiguration('ruby.rubocop');
+    let useBundler;
+    let path = conf.get('executePath', '');
+    let command;
+
+    // if executePath is present in workspace config, use it.
+    if (path.length !== 0) {
+        command = path + cmd;
+    } else if (detectBundledRubocop()) {
+        useBundler = true;
+        command = `bundle exec ${cmd}`;
+    } else {
+        path = autodetectExecutePath(cmd);
+        if (0 === path.length) {
+            vs.window.showWarningMessage('execute path is empty! please check ruby.rubocop.executePath');
+        }
+        command = path + cmd;
+    }
+    return {
+        useBundler,
+        command,
+        configFilePath: conf.get('configFilePath', ''),
+        onSave: conf.get('onSave', true),
+    };
+};
+
+const detectBundledRubocop: () => boolean = () => {
+    try {
+        cp.execSync('bundle show rubocop', { cwd: vs.workspace.rootPath });
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+const autodetectExecutePath: (cmd: string) => string = (cmd) => {
+    const key: string = 'PATH';
+    let paths = process.env[key];
+    if (!paths) {
+        return '';
+    }
+
+    let pathparts = paths.split(path.delimiter);
+    for (let i = 0; i < pathparts.length; i++) {
+        let binpath = path.join(pathparts[i], cmd);
+        if (fs.existsSync(binpath)) {
+            return pathparts[i] + path.sep;
+        }
+    }
+
+    return '';
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 
 import * as vscode from 'vscode';
 import Rubocop from './rubocop';
+import { onDidChangeConfiguration } from './configuration';
 
 // entry point of extension
 export function activate(context: vscode.ExtensionContext): void {
@@ -32,6 +33,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(disposable);
 
     const ws = vscode.workspace;
+
+    ws.onDidChangeConfiguration(onDidChangeConfiguration(rubocop));
 
     ws.textDocuments.forEach((e: vscode.TextDocument) => {
         rubocop.execute(e);

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -1,0 +1,89 @@
+import { expect } from 'chai';
+import * as cp from 'child_process';
+import * as pq from 'proxyquire';
+
+const childProcessStub: any = {};
+const extensionConfig = pq('../src/configuration', {
+  'child_process': childProcessStub,
+});
+
+const { RubocopConfig, getConfig } = extensionConfig;
+const canFindBundledCop = () => new Buffer('path/to/bundled/rubocop');
+const cannotFindBundledCop = () => { throw new Error('not found'); };
+
+describe('RubocopConfig', () => {
+
+  describe('getConfig', () => {
+    describe('.useBundler', () => {
+      it('is set to true if a bundled rubocop is found', () => {
+        childProcessStub.execSync = canFindBundledCop;
+        expect(getConfig()).to.have.property('useBundler', true);
+      });
+
+      it('is unset if a bundled rubocop is not found', () => {
+        childProcessStub.execSync = cannotFindBundledCop;
+        expect(getConfig()).to.have.property('useBundler', undefined);
+      });
+
+    });
+
+    describe('.command', () => {
+      describe('win32 platform', () => {
+        beforeEach(() => {
+          this.originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+          Object.defineProperty(process, 'platform', {
+            value: 'win32',
+          });
+        });
+        afterEach(() => {
+          Object.defineProperty(process, 'platform', this.originalPlatform);
+        });
+
+        it('is set to "bundle exec rubocop.bat" if bundled rubocop is present', () => {
+          childProcessStub.execSync = canFindBundledCop;
+          expect(getConfig()).to.have.property('command', 'bundle exec rubocop.bat');
+        });
+
+        it('is set to "rubocop.bat" otherwise', () => {
+          childProcessStub.execSync = cannotFindBundledCop;
+          expect(getConfig()).to.have.property('command', 'rubocop.bat');
+        });
+      });
+
+      describe('non-win32 platform', () => {
+        beforeEach(() => {
+          this.originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+          Object.defineProperty(process, 'platform', {
+            value: 'commodore64',
+          });
+        });
+        afterEach(() => {
+          Object.defineProperty(process, 'platform', this.originalPlatform);
+        });
+
+        it('is set to "bundle exec rubocop" if bundled rubocop is present', () => {
+          childProcessStub.execSync = canFindBundledCop;
+          expect(getConfig()).to.have.property('command', 'bundle exec rubocop');
+        });
+
+        it('is set to "path/to/rubocop" otherwise', () => {
+          childProcessStub.execSync = cannotFindBundledCop;
+          expect(getConfig().command).to.match(/.*rubocop$/);
+        });
+
+      });
+
+      describe('.configFilePath', () => {
+        it('is set', () => {
+          expect(getConfig()).to.have.property('configFilePath');
+        });
+      });
+
+      describe('.onSave', () => {
+        it('is set', () => {
+          expect(getConfig()).to.have.property('onSave');
+        });
+      });
+    });
+  });
+});

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -17,48 +17,5 @@ describe('Rubocop', () => {
         expect(instance).to.have.property('diag', diagnostics);
       });
     });
-
-    describe('.command', () => {
-      describe('when process.platform is "win32"', () => {
-        beforeEach(() => {
-          instance = new Rubocop(diagnostics, undefined, 'win32');
-        });
-
-        it('is set to "rubocop.bat"', () => {
-          expect(instance).to.have.property('command', 'rubocop.bat');
-        });
-      });
-
-      describe('when process.platform is not "win32"', () => {
-        beforeEach(() => {
-          instance = new Rubocop(diagnostics, undefined, 'linux');
-        });
-
-        it('is set to "rubocop"', () => {
-          expect(instance).to.have.property('command', 'rubocop');
-        });
-      });
-    });
-
-    // note: these properties are currently set by Rubocop.resetConfig
-    describe('configuration', () => {
-      describe('.path', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('path');
-        });
-      });
-
-      describe('.configPath', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('configPath');
-        });
-      });
-
-      describe('.onSave', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('onSave');
-        });
-      });
-    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,13 @@ filename-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -776,6 +783,10 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1007,6 +1018,10 @@ map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
 
+merge-descriptors@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 merge-stream@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -1076,6 +1091,10 @@ mocha@^3.2.0, mocha@^3.3.0:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
+
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
 ms@0.7.2:
   version "0.7.2"
@@ -1215,6 +1234,14 @@ preserve@^0.2.0:
 process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+proxyquire@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.1.7"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -1359,6 +1386,10 @@ resolve@^1.3.2:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 rimraf@2:
   version "2.6.1"


### PR DESCRIPTION
 - resolves #34 

- [x] Add tests
- ? Confirm how commands should be executed for windows environment -> After some research, including looking into sirlantis/rubocop-for-rubymine#9 I just don't feel qualified to address this. I would probably recommend using the `executePath` option in the case of a win32 user, If this is alright I'd say this PR is ready.

This PR updates vscode-ruby-rubocop to set the rubocop command with the following precedence:

- executePath in config
- Presence of rubocop in Gemfile (using bundle show rubocop)
- Currently-existing autodetect method

Using bundler resolves many errors around changes to cop namespaces and configuration as well- see #51 and #43

It also takes advantage of the (unused?) RubocopConfig interface and moves configuration into a separate file, addressing the todo to leverage the onDidChangeConfiguration vscode hook.

Still needs test updates and clarification on how bundler works in a windows environment.