### PR TITLE
Set autocorrect as a formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
         "title": "Ruby: lint by rubocop"
       },
       {
-        "command": "ruby.rubocopAutocorrect",
+        "command": "editor.action.formatDocument",
         "title": "Ruby: autocorrect by rubocop"
       }
     ],
     "keybindings": [
       {
         "key": "shift+ctrl+r",
-        "command": "ruby.rubocopAutocorrect",
+        "command": "editor.action.formatDocument",
         "when": "editorLangId == 'ruby'"
       }
     ],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,7 @@ import * as vs from 'vscode';
 import * as fs from 'fs';
 import * as cp from 'child_process';
 import * as path from 'path';
-import Rubocop from './rubocop';
+import { Rubocop } from './rubocop';
 
 export interface RubocopConfig {
     command: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 
 import * as vscode from 'vscode';
-import Rubocop from './rubocop';
+import { Rubocop, RubocopAutocorrectProvider } from './rubocop';
 import { onDidChangeConfiguration } from './configuration';
 
 // entry point of extension
@@ -8,20 +8,6 @@ export function activate(context: vscode.ExtensionContext): void {
     'use strict';
 
     const diag = vscode.languages.createDiagnosticCollection('ruby');
-    const rubocopAutocorrect = new Rubocop(diag, ['--auto-correct']);
-
-    vscode.commands.registerCommand('ruby.rubocopAutocorrect', () => {
-        const document = vscode.window.activeTextEditor.document;
-
-        if (document.languageId !== 'ruby') {
-            return;
-        }
-
-        document.save().then(() => {
-            rubocopAutocorrect.execute(document, () => rubocop.execute(document));
-        });
-    });
-
     context.subscriptions.push(diag);
 
     const rubocop = new Rubocop(diag);
@@ -53,4 +39,6 @@ export function activate(context: vscode.ExtensionContext): void {
     ws.onDidCloseTextDocument((e: vscode.TextDocument) => {
         rubocop.clear(e);
     });
+    const formattingProvider = new RubocopAutocorrectProvider;
+    vscode.languages.registerDocumentFormattingEditProvider('ruby', formattingProvider);
 }

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as vscode from 'vscode';
-import Rubocop from '../src/rubocop';
+import { Rubocop } from '../src/rubocop';
 
 describe('Rubocop', () => {
   let instance: Rubocop;


### PR DESCRIPTION
It allows running autocorrect even for not existing files (new buffers).
It doesn't clean the history of changes.
`rubocop.autocorrect command` is an alias for format document.

fixes #48 