### PR TITLE
Split config.command into command and args

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -19,9 +19,10 @@ export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEdit
             return [new vscode.TextEdit(this.getFullRange(document), newText)];
         };
         try {
+            const cmd = config.command.split(/\s+/)
             cp.execFileSync(
-                config.command,
-                [tmpFileName, ...getCommandArguments(tmpFileName), '--auto-correct'],
+                cmd.pop(),
+                [...cmd, tmpFileName, ...getCommandArguments(tmpFileName), '--auto-correct'],
                 { cwd: getCurrentPath(document.fileName) },
             );
         } catch (e) {


### PR DESCRIPTION
execFileSync expects a single command without arguments. config.command defaults to 'bundle exec rubocop' when bundler is detected. therefore config.command is splitted into the comand and it's arguments.