### PR TITLE
[BUG] Fix autocorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "main": "./out/src/extension",
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
+    "format": "tsfmt -r src/*",
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test"

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -45,7 +45,7 @@ export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEdit
                 this.getFullRange(document),
                 stdout
                     .toString()
-                    .split("\n")
+                    .split("====================\n")
                     .slice(1)
                     .join("\n") // json is written to 1st line, autocorrected file starts on 2nd line
             )

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -7,36 +7,50 @@ import * as vscode from 'vscode';
 import { getConfig, RubocopConfig } from './configuration';
 import * as os from 'os';
 
-const tmpFileName = path.join(os.tmpdir(), '_rubocop.rb');
-
 export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEditProvider {
     public provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         const config = getConfig();
-        fs.writeFileSync(tmpFileName, document.getText());
-        const onSuccess = () => {
-            const newText = fs.readFileSync(tmpFileName).toString();
-            fs.unlink(tmpFileName);
-            return [new vscode.TextEdit(this.getFullRange(document), newText)];
-        };
+
         try {
-            const cmd = config.command.split(/\s+/)
-            cp.execFileSync(
-                cmd.pop(),
-                [...cmd, tmpFileName, ...getCommandArguments(tmpFileName), '--auto-correct'],
-                { cwd: getCurrentPath(document.fileName) },
-            );
+            const args = [
+                ...getCommandArguments(document.fileName),
+                "--auto-correct"
+            ];
+            const options = {
+                cwd: getCurrentPath(document.fileName),
+                input: document.getText()
+            };
+            let stdout;
+            if (config.useBundler) {
+                stdout = cp.execSync(`${config.command} ${args.join(" ")}`, options);
+            } else {
+                stdout = cp.execFileSync(config.command, args, options);
+            }
+
+            return this.onSuccess(document, stdout);
         } catch (e) {
             // if there are still some offences not fixed rubocop will return status 1
             if (e.status !== 1) {
                 vscode.window.showWarningMessage('An error occured during autocorrection');
                 console.log(e);
-                fs.unlink(tmpFileName);
                 return [];
             } else {
-                return onSuccess();
+                return this.onSuccess(document, e);
             }
         }
-        return onSuccess();
+    }
+
+    private onSuccess(document: vscode.TextDocument, stdout) {
+        return [
+            new vscode.TextEdit(
+                this.getFullRange(document),
+                stdout
+                    .toString()
+                    .split("\n")
+                    .slice(1)
+                    .join("\n") // json is written to 1st line, autocorrected file starts on 2nd line
+            )
+        ];
     }
 
     private getFullRange(document: vscode.TextDocument): vscode.Range {
@@ -57,7 +71,13 @@ function getCurrentPath(fileName: string): string {
 
 // extract argument to an array
 function getCommandArguments(fileName: string): string[] {
-    let commandArguments = [fileName, '--format', 'json', '--force-exclusion'];
+    let commandArguments = [
+        "--stdin",
+        fileName,
+        "--format",
+        "json",
+        "--force-exclusion"
+    ];
     const extensionConfig = getConfig();
     if (extensionConfig.configFilePath !== '') {
         if (fs.existsSync(extensionConfig.configFilePath)) {
@@ -130,7 +150,7 @@ export class Rubocop {
         const args = getCommandArguments(fileName).concat(this.additionalArguments);
 
         let task = new Task(uri, token => {
-            let process = this.executeRubocop(args, { cwd: currentPath }, (error, stdout, stderr) => {
+            let process = this.executeRubocop(args, document.getText(), { cwd: currentPath }, (error, stdout, stderr) => {
                 if (token.isCanceled) {
                     return;
                 }
@@ -157,16 +177,23 @@ export class Rubocop {
         }
     }
 
+
     // execute rubocop
     private executeRubocop(
         args: string[],
+        fileContents: string,
         options: cp.ExecFileOptions,
-        cb: (err: Error, stdout: string, stderr: string) => void): cp.ChildProcess {
+        cb: (err: Error, stdout: string, stderr: string) => void
+    ): cp.ChildProcess {
+        let child;
         if (this.config.useBundler) {
-            return cp.exec(`${this.config.command} ${args.join(' ')}`, options, cb);
+            child = cp.exec(`${this.config.command} ${args.join(" ")}`, options, cb);
         } else {
-            return cp.execFile(this.config.command, args, options, cb);
+            child = cp.execFile(this.config.command, args, options, cb);
         }
+        child.stdin.write(fileContents);
+        child.stdin.end();
+        return child;
     }
 
     // parse rubocop(JSON) output

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -10,7 +10,6 @@ import * as os from 'os';
 export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEditProvider {
     public provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
         const config = getConfig();
-
         try {
             const args = [
                 ...getCommandArguments(document.fileName),
@@ -40,7 +39,7 @@ export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEdit
         }
     }
 
-    private onSuccess(document: vscode.TextDocument, stdout) {
+    private onSuccess(document: vscode.TextDocument, stdout: Buffer) {
         return [
             new vscode.TextEdit(
                 this.getFullRange(document),
@@ -71,13 +70,7 @@ function getCurrentPath(fileName: string): string {
 
 // extract argument to an array
 function getCommandArguments(fileName: string): string[] {
-    let commandArguments = [
-        "--stdin",
-        fileName,
-        "--format",
-        "json",
-        "--force-exclusion"
-    ];
+    let commandArguments = ['--stdin', fileName, '--format', 'json', '--force-exclusion'];
     const extensionConfig = getConfig();
     if (extensionConfig.configFilePath !== '') {
         if (fs.existsSync(extensionConfig.configFilePath)) {
@@ -183,11 +176,10 @@ export class Rubocop {
         args: string[],
         fileContents: string,
         options: cp.ExecFileOptions,
-        cb: (err: Error, stdout: string, stderr: string) => void
-    ): cp.ChildProcess {
+        cb: (err: Error, stdout: string, stderr: string) => void): cp.ChildProcess {
         let child;
         if (this.config.useBundler) {
-            child = cp.exec(`${this.config.command} ${args.join(" ")}`, options, cb);
+            child = cp.exec(`${this.config.command} ${args.join(' ')}`, options, cb);
         } else {
             child = cp.execFile(this.config.command, args, options, cb);
         }

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -34,7 +34,7 @@ export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEdit
                 console.log(e);
                 return [];
             } else {
-                return this.onSuccess(document, e);
+                return this.onSuccess(document, e.stdout);
             }
         }
     }


### PR DESCRIPTION
Autocorrect was not respecting the `.rubocop.yml` (I think) because even though the `cwd` was being set to the project root, the actual file being autocorrected was in a `tmp` directory. 

#### Repro the bug
The way I repro'd the incorrect behaviour is something like this:
1. Enforce any arbitrary rule that deviates from the standard rubocop config. For example:
```yaml
Style/FrozenStringLiteralComment:
  Enabled: false
```
2. Autocorrect the file
3. Observe that it has inserted the frozen string literal comment

---

I don't really see the need the need to use a tmp file at all. Rubocop provides a `--stdin` option specifically for editor integrations so it's better to leverage that instead of creating/inserting/reading/deleting a file every time you autocorrect.

Additions:
1. Added a `format` command to package.json so that contributors can easily run `yarn run format` before they commit
2. Replace the `tmp` file usage described above with stdin/stdout buffers

The specs didn't break so I'm wondering how well tested this is. I don't write much Typescript so please be gentle 😄 