### PR TITLE
Fix autoCorrection find on windows

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -50,7 +50,7 @@ export class RubocopAutocorrectProvider implements vscode.DocumentFormattingEdit
     // So we need to parse out the actual autocorrected ruby
     private onSuccess(document: vscode.TextDocument, stdout: Buffer) {
         const stringOut = stdout.toString()
-        const autoCorrection = stringOut.match(/^{.*}====================\n([.\s\S]*)/m)
+        const autoCorrection = stringOut.match(/^{.*}====================(?:\n|\r\n)([.\s\S]*)/m)
         if (!autoCorrection) {
             throw new Error(`Error parsing autocorrection from CLI: ${stringOut}`)
         }


### PR DESCRIPTION
Current implementation for extracting the corrected result from the output fails on windows due to line ending types.