### PR TITLE
Using relative config file path

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -83,13 +83,21 @@ function getCommandArguments(fileName: string): string[] {
     let commandArguments = ['--stdin', fileName, '--format', 'json', '--force-exclusion'];
     const extensionConfig = getConfig();
     if (extensionConfig.configFilePath !== '') {
-        if (fs.existsSync(extensionConfig.configFilePath)) {
-            const config = ['--config', extensionConfig.configFilePath];
-            commandArguments = commandArguments.concat(config);
-        } else {
-            vscode.window.showWarningMessage(`${extensionConfig.configFilePath} file does not exist. Ignoring...`);
+      
+      let found = [extensionConfig.configFilePath].concat(
+        (vscode.workspace.workspaceFolders || []).map((ws: any) => path.join(ws.uri.path, extensionConfig.configFilePath))
+      ).filter((p: string) => fs.existsSync(p));
+
+      if (found.length == 0) {
+        vscode.window.showWarningMessage(`${extensionConfig.configFilePath} file does not exist. Ignoring...`);
+      } else {
+        if (found.length > 1) {
+          vscode.window.showWarningMessage(`Found multiple files (${found}) will use ${found[0]}`);
         }
-    }
+        const config = ['--config', found[0]];
+        commandArguments = commandArguments.concat(config);
+      }
+  }
 
     return commandArguments;
 }


### PR DESCRIPTION
The fix appends the config file string to all workspace folders, then checks where a file can be found.
If multiple are found a warning is displayed, otherwise works as before. 