### PR TITLE
Eliminate `workspace.rootPath` due to its deprecation

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -19,7 +19,7 @@ export class RubocopAutocorrectProvider
         '--auto-correct',
       ];
       const options = {
-        cwd: getCurrentPath(document.fileName),
+        cwd: getCurrentPath(document.uri),
         input: document.getText(),
       };
       let stdout;
@@ -77,11 +77,9 @@ function isFileUri(uri: vscode.Uri): boolean {
   return uri.scheme === 'file';
 }
 
-function getCurrentPath(fileName: string): string {
-  const wsfolder = vscode.workspace.getWorkspaceFolder(
-    vscode.Uri.file(fileName)
-  );
-  return (wsfolder && wsfolder.uri.fsPath) || path.dirname(fileName);
+function getCurrentPath(fileUri: vscode.Uri): string {
+  const wsfolder = vscode.workspace.getWorkspaceFolder(fileUri);
+  return (wsfolder && wsfolder.uri.fsPath) || path.dirname(fileUri.fsPath);
 }
 
 // extract argument to an array
@@ -146,7 +144,7 @@ export class Rubocop {
 
     const fileName = document.fileName;
     const uri = document.uri;
-    let currentPath = getCurrentPath(fileName);
+    let currentPath = getCurrentPath(uri);
 
     let onDidExec = (error: Error, stdout: string, stderr: string) => {
       this.reportError(error, stderr);

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -78,7 +78,10 @@ function isFileUri(uri: vscode.Uri): boolean {
 }
 
 function getCurrentPath(fileName: string): string {
-  return vscode.workspace.rootPath || path.dirname(fileName);
+  const wsfolder = vscode.workspace.getWorkspaceFolder(
+    vscode.Uri.file(fileName)
+  );
+  return (wsfolder && wsfolder.uri.fsPath) || path.dirname(fileName);
 }
 
 // extract argument to an array


### PR DESCRIPTION
`workspace.rootPath` is now deprecated as of:
https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs

> If your extension is making use of the (now deprecated) workspace.rootPath property to work on the currently opened folder, then you are affected. See the section 'Eliminating workspace.rootPath below'.

This causes the extension not to function properly in multi-root environments. Rubocop will be always run through the system's default Ruby interpreter which is not always desired. Different projects can have different versions of Ruby and different versions of Rubocop.

We should use `workspace.getWorkspaceFolder(uri)` instead according to:
https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs#eliminating-rootpath