### PR TITLE
feat(configuration): add enableUnsafeAutoCorrection configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
   "ruby.rubocop.configFilePath": "/path/to/config/.rubocop.yml",
 
   // default true
-  "ruby.rubocop.onSave": true
+  "ruby.rubocop.onSave": true,
+
+  // default false
+  "ruby.rubocop.enableUnsafeAutoCorrection": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress warnings from rubocop and attempt to run regardless. (Useful if you share a rubocop.yml file and run into unrecognized cop errors you know are okay.)"
+        },
+        "ruby.rubocop.enableUnsafeAutoCorrection": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable unsafe auto-correction using --auto-correct-all rubocop's flag"
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,6 +10,7 @@ export interface RubocopConfig {
   configFilePath: string;
   useBundler: boolean;
   suppressRubocopWarnings: boolean;
+  enableUnsafeAutoCorrection: boolean;
 }
 
 const detectBundledRubocop: () => boolean = () => {
@@ -50,6 +51,7 @@ export const getConfig: () => RubocopConfig = () => {
   let useBundler = conf.get('useBundler', false);
   let configPath = conf.get('executePath', '');
   let suppressRubocopWarnings = conf.get('suppressRubocopWarnings', false);
+  let enableUnsafeAutoCorrection = conf.get('enableUnsafeAutoCorrection', false);
   let command;
 
   // if executePath is present in workspace config, use it.
@@ -74,6 +76,7 @@ export const getConfig: () => RubocopConfig = () => {
     onSave: conf.get('onSave', true),
     useBundler,
     suppressRubocopWarnings,
+    enableUnsafeAutoCorrection,
   };
 };
 

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -16,7 +16,9 @@ export class RubocopAutocorrectProvider
     try {
       const args = [
         ...getCommandArguments(document.fileName),
-        '--auto-correct',
+        config.enableUnsafeAutoCorrection ?
+          '--auto-correct-all'
+          : '--auto-correct',
       ];
       const options = {
         cwd: getCurrentPath(document.fileName),

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -21,6 +21,7 @@ vsStub.workspace.getConfiguration = (
     onSave: true,
     useBundler: false,
     suppressRubocopWarnings: false,
+    enableUnsafeAutoCorrection: false,
   };
 
   return {
@@ -62,6 +63,12 @@ describe('RubocopConfig', () => {
     describe('.suppressRubocopWarnings', () => {
       it('is set to false', () => {
         expect(getConfig()).to.have.property('suppressRubocopWarnings', false);
+      });
+    });
+
+    describe('.enableUnsafeAutoCorrection', () => {
+      it('is set to false', () => {
+        expect(getConfig()).to.have.property('enableUnsafeAutoCorrection', false);
       });
     });
 


### PR DESCRIPTION
The purpose of this PR is to add a `ruby.rubocop.enableUnsafeAutoCorrection` configuration option to run Rubocop auto-correction with the `--auto-correct-all` flag instead of the default `--auto-correct` one.

I'm not an expert neither with VS Code extension development nor with Rubocop so feel free to commit improvement to this pull request.