### PR TITLE
Cops with Info-level severity should display as info-level

### DIFF
--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -280,6 +280,7 @@ export class Rubocop {
       case 'refactor':
         return vscode.DiagnosticSeverity.Hint;
       case 'convention':
+      case 'info':
         return vscode.DiagnosticSeverity.Information;
       case 'warning':
         return vscode.DiagnosticSeverity.Warning;


### PR DESCRIPTION
### What
Added a case that renders cops with `info` level severity as `DiagnosticSeverity.Information`.

### Why
Currently, cops that are set to return info-level severity are rendered as warnings, with a red underline and a red warning icon. Per the [Rubocop documentation](https://docs.rubocop.org/rubocop/configuration.html#severity) `info` is the lowest level, ranking even below `refactor` so it should definitely not be displayed as something more severe. Because of its name matching the name and the icon of the `Information` diagnostic severity I chose to use that one instead of using the lower level `Hint` one and grouping it with `refactor`.