### PR TITLE
Added autocorrectArg config option for --auto-correct-all (-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,13 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
   // "ruby.rubocop.executePath": "/Users/you/.rvm/gems/ruby-2.3.2/bin/"
   // "ruby.rubocop.executePath": "D:/bin/Ruby22-x64/bin/"
 
+  // Set to "--auto-correct-all" to enable "unsafe" auto-corrections
+  "ruby.rubocop.autocorrectArg": "--auto-correct",
+
   // If not specified, it assumes a null value by default.
   "ruby.rubocop.configFilePath": "/path/to/config/.rubocop.yml",
 
-  // default true
+  // default: true
   "ruby.rubocop.onSave": true
 }
 ```

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
           "default": "",
           "description": "execution path of rubocop."
         },
+        "ruby.rubocop.autocorrectArg": {
+          "type": "string",
+          "default": "--auto-correct",
+          "description": "RuboCop argument for autocorrect. Use --auto-correct-all to include unsafe autocorrections."
+        },
         "ruby.rubocop.configFilePath": {
           "type": "string",
           "default": "",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,6 +6,7 @@ import { Rubocop } from './rubocop';
 
 export interface RubocopConfig {
   command: string;
+  autocorrectArg: string;
   onSave: boolean;
   configFilePath: string;
   useBundler: boolean;
@@ -70,6 +71,7 @@ export const getConfig: () => RubocopConfig = () => {
 
   return {
     command,
+    autocorrectArg: conf.get('autocorrectArg', '--auto-correct'),
     configFilePath: conf.get('configFilePath', ''),
     onSave: conf.get('onSave', true),
     useBundler,

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -17,7 +17,7 @@ export class RubocopAutocorrectProvider
     try {
       const args = [
         ...getCommandArguments(document.fileName),
-        '--auto-correct',
+        config.autocorrectArg, // Default: --auto-correct
       ];
       const options = {
         cwd: getCurrentPath(document.uri),

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -18,6 +18,7 @@ vsStub.workspace.getConfiguration = (
   const defaultConfig = {
     configfilePath: '',
     executePath: '',
+    autocorrectArg: '--auto-correct',
     onSave: true,
     useBundler: false,
     suppressRubocopWarnings: false,
@@ -133,6 +134,12 @@ describe('RubocopConfig', () => {
       describe('.onSave', () => {
         it('is set', () => {
           expect(getConfig()).to.have.property('onSave');
+        });
+      });
+
+      describe('.autocorrectArg', () => {
+        it('is set', () => {
+          expect(getConfig().autocorrectArg).to.eq('--auto-correct');
         });
       });
     });


### PR DESCRIPTION
Related: #49

I like the `--auto-correct-all` (or `-A`) option with RuboCop to automatically refactor and fix code. This change allows me to use `-A` for "formatOnSave" by using `"ruby.rubocop.autocorrectArg": "--auto-correct-all"` in my VS Code settings.