### PR TITLE
Added postFormatVSCodeCommand option, so that I can use RuboCop and Prettier for Ruby at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
   // If not specified, it assumes a null value by default.
   "ruby.rubocop.configFilePath": "/path/to/config/.rubocop.yml",
 
-  // default true
+  // default: true
   "ruby.rubocop.onSave": true
+
+  // VSCode command to run after formatting the document. E.g. prettier.forceFormatDocument
+  "ruby.rubocop.postFormatVSCodeCommand": ""
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress warnings from rubocop and attempt to run regardless. (Useful if you share a rubocop.yml file and run into unrecognized cop errors you know are okay.)"
+        },
+        "ruby.rubocop.postFormatVSCodeCommand": {
+          "type": "string",
+          "default": "",
+          "description": "VSCode command to run after formatting the document. E.g. prettier.forceFormatDocument"
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,6 +10,7 @@ export interface RubocopConfig {
   configFilePath: string;
   useBundler: boolean;
   suppressRubocopWarnings: boolean;
+  postFormatVSCodeCommand: string;
 }
 
 const detectBundledRubocop: () => boolean = () => {
@@ -50,6 +51,7 @@ export const getConfig: () => RubocopConfig = () => {
   let useBundler = conf.get('useBundler', false);
   const configPath = conf.get('executePath', '');
   const suppressRubocopWarnings = conf.get('suppressRubocopWarnings', false);
+  const postFormatVSCodeCommand = conf.get('postFormatVSCodeCommand', '');
   let command: string;
 
   // if executePath is present in workspace config, use it.
@@ -67,13 +69,14 @@ export const getConfig: () => RubocopConfig = () => {
     }
     command = detectedPath + cmd;
   }
-
+  
   return {
     command,
     configFilePath: conf.get('configFilePath', ''),
     onSave: conf.get('onSave', true),
     useBundler,
     suppressRubocopWarnings,
+    postFormatVSCodeCommand
   };
 };
 

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -29,7 +29,7 @@ export class RubocopAutocorrectProvider
       } else {
         stdout = cp.execFileSync(config.command, args, options);
       }
-
+      this.runPostFormatVSCodeCommand(config);
       return this.onSuccess(document, stdout);
     } catch (e) {
       // if there are still some offences not fixed RuboCop will return status 1
@@ -40,9 +40,18 @@ export class RubocopAutocorrectProvider
         console.log(e);
         return [];
       } else {
+        this.runPostFormatVSCodeCommand(config);
         return this.onSuccess(document, e.stdout);
       }
     }
+  }
+
+  private runPostFormatVSCodeCommand(config) {
+    if (!config.postFormatVSCodeCommand) return;
+    
+    setTimeout(() => {
+      vscode.commands.executeCommand(config.postFormatVSCodeCommand);
+    }, 50);
   }
 
   // Output of auto-correction looks like this:


### PR DESCRIPTION
I really like how RuboCop can fix linting issues as well as formatting the code. However, I prefer the way that [Prettier for Ruby](https://github.com/prettier/plugin-ruby) formats code since it's much more opinionated, and it does a much better job with hashes. Prettier can automatically split and indent hashes across multiple lines, but RuboCop can't do this.

I tried to switch to Prettier, but then I really missed all the extra things that RuboCop was doing for me.

This new option allows me to call `prettier.forceFormatDocument` from the Prettier VS Code extension to format the code after RuboCop has fixed all of the linting issues. Thanks!