### PR TITLE
Make Ruby: autocorrect by rubocop work even when Rubocop isn't the default formatter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         "title": "Ruby: lint by rubocop"
       },
       {
-        "command": "editor.action.formatDocument",
+        "command": "ruby.rubocop.autocorrect",
+        "when": "editorLangId == 'ruby' || editorLangId == 'gemfile'",
         "title": "Ruby: autocorrect by rubocop"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,4 +47,20 @@ export function activate(context: vscode.ExtensionContext): void {
     'gemfile',
     formattingProvider
   );
+
+  const autocorrectDisposable = vscode.commands.registerCommand('ruby.rubocop.autocorrect', () => {
+    vscode.window.activeTextEditor.edit((editBuilder) => {
+      const document = vscode.window.activeTextEditor.document;
+      const edits = formattingProvider.provideDocumentFormattingEdits(document);
+      // We only expect one edit from our formatting provider.
+      if (edits.length === 1) {
+        const edit = edits[0];
+        editBuilder.replace(edit.range, edit.newText);
+      }
+      if (edits.length > 1) {
+        throw new Error("Unexpected error: Rubocop document formatter returned multiple edits.");
+      }
+    });
+  });
+  context.subscriptions.push(autocorrectDisposable);
 }


### PR DESCRIPTION
This change makes the "Ruby: autocorrect by rubocop" command work even when Rubocop isn't the default formatter.

Before this change, if Rubocop is not the default formatter, running "Rubocop: autocorrect by rubocop" would
run the default formatter and not Rubocop.

Now, this command manually applies Rubocop's autocorrects to the current document.

We are encountering this bug at Stripe and would love it if this fix could be merged and a new version of the extension released. :)