### PR TITLE
Don't warn "Found multiple files" when they are the same file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gem install rubocop
 
 If VSCode market place is not configured in your FLOSS distribution of code (you have Open VSX instead):
 
-1. Go on [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=misogi.ruby-rubocop) and clic on the [Download Extension](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/misogi/vsextensions/ruby-rubocop/0.8.5/vspackage) button.
+1. Go on [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=misogi.ruby-rubocop) and click on the [Download Extension](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/misogi/vsextensions/ruby-rubocop/0.8.5/vspackage) button.
 2. Install the extension manually from the CLI: `code --install-extension misogi.ruby-rubocop-0.8.5.vsix`
 
 # ChangeLog

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -89,11 +89,7 @@ function getCommandArguments(fileName: string): string[] {
   const extensionConfig = getConfig();
 
   if (extensionConfig.configFilePath !== '') {
-    const expandedConfigFilePath = path.isAbsolute(
-      extensionConfig.configFilePath
-    )
-      ? extensionConfig.configFilePath
-      : path.resolve(extensionConfig.configFilePath);
+    const expandedConfigFilePath = path.resolve(extensionConfig.configFilePath);
 
     const found = [expandedConfigFilePath]
       .concat(

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -87,13 +87,22 @@ function getCurrentPath(fileUri: vscode.Uri): string {
 function getCommandArguments(fileName: string): string[] {
   let commandArguments = ['--stdin', fileName, '--force-exclusion'];
   const extensionConfig = getConfig();
+
   if (extensionConfig.configFilePath !== '') {
-    const found = [extensionConfig.configFilePath]
+    const expandedConfigFilePath = path.isAbsolute(
+      extensionConfig.configFilePath
+    )
+      ? extensionConfig.configFilePath
+      : path.resolve(extensionConfig.configFilePath);
+
+    const found = [expandedConfigFilePath]
       .concat(
         (vscode.workspace.workspaceFolders || []).map((ws) =>
           path.join(ws.uri.path, extensionConfig.configFilePath)
         )
       )
+      // dedupe
+      .filter((v, i, a) => a.indexOf(v) === i)
       .filter((p: string) => fs.existsSync(p));
 
     if (found.length == 0) {


### PR DESCRIPTION
Solves this comment https://github.com/misogi/vscode-ruby-rubocop/issues/62#issuecomment-1342963851

I tested locally by installing from dev build like:

```shell
yarn vscode:prepublish
yarn global add vsce
$(yarn global bin)/vsce package
code --install-extension ruby-rubocop-0.8.6.vsix
```

And I no longer get the warning:

![image](https://user-images.githubusercontent.com/4197823/206538463-088c40e2-4440-4b03-a954-adcb72b79f0d.png)
