### PR TITLE
Support rubocop server

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
       {
         "command": "editor.action.formatDocument",
         "title": "Ruby: autocorrect by rubocop"
+      },
+      {
+        "command": "ruby.rubocop.restart_server",
+        "title": "Ruby: restart rubocop server"
       }
     ],
     "keybindings": [
@@ -85,6 +89,11 @@
           "type": "boolean",
           "default": false,
           "description": "execute rubocop using bundler (ie 'bundle exec rubocop')"
+        },
+        "ruby.rubocop.useServer": {
+          "type": "boolean",
+          "default": false,
+          "description": "execute rubocop in server mode (ie 'rubocop --server')"
         },
         "ruby.rubocop.suppressRubocopWarnings": {
           "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -9,6 +9,7 @@ export interface RubocopConfig {
   onSave: boolean;
   configFilePath: string;
   useBundler: boolean;
+  useServer: boolean;
   suppressRubocopWarnings: boolean;
 }
 
@@ -48,6 +49,7 @@ export const getConfig: () => RubocopConfig = () => {
   const cmd = win32 ? 'rubocop.bat' : 'rubocop';
   const conf = vs.workspace.getConfiguration('ruby.rubocop');
   let useBundler = conf.get('useBundler', false);
+  let useServer = conf.get('useServer', false);
   const configPath = conf.get('executePath', '');
   const suppressRubocopWarnings = conf.get('suppressRubocopWarnings', false);
   let command: string;
@@ -73,6 +75,7 @@ export const getConfig: () => RubocopConfig = () => {
     configFilePath: conf.get('configFilePath', ''),
     onSave: conf.get('onSave', true),
     useBundler,
+    useServer,
     suppressRubocopWarnings,
   };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { Rubocop, RubocopAutocorrectProvider } from './rubocop';
 import { onDidChangeConfiguration } from './configuration';
 
+let rubocop: Rubocop;
+
 // entry point of extension
 export function activate(context: vscode.ExtensionContext): void {
   'use strict';
@@ -9,13 +11,22 @@ export function activate(context: vscode.ExtensionContext): void {
   const diag = vscode.languages.createDiagnosticCollection('ruby');
   context.subscriptions.push(diag);
 
-  const rubocop = new Rubocop(diag);
+  rubocop = new Rubocop(diag);
   const disposable = vscode.commands.registerCommand('ruby.rubocop', () => {
     const document = vscode.window.activeTextEditor.document;
     rubocop.execute(document);
   });
 
   context.subscriptions.push(disposable);
+
+  const restart = vscode.commands.registerCommand(
+    'ruby.rubocop.restart_server',
+    () => {
+      rubocop.restart();
+    }
+  );
+
+  context.subscriptions.push(restart);
 
   const ws = vscode.workspace;
 
@@ -47,4 +58,10 @@ export function activate(context: vscode.ExtensionContext): void {
     'gemfile',
     formattingProvider
   );
+}
+
+export function deactivate(): void {
+  if (rubocop) {
+    rubocop.stop();
+  }
 }

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -87,6 +87,9 @@ function getCurrentPath(fileUri: vscode.Uri): string {
 function getCommandArguments(fileName: string): string[] {
   let commandArguments = ['--stdin', fileName, '--force-exclusion'];
   const extensionConfig = getConfig();
+  if (extensionConfig.useServer) {
+    commandArguments = commandArguments.concat('--server');
+  }
   if (extensionConfig.configFilePath !== '') {
     const found = [extensionConfig.configFilePath]
       .concat(
@@ -209,6 +212,24 @@ export class Rubocop {
     if (isFileUri(uri)) {
       this.taskQueue.cancel(uri);
       this.diag.delete(uri);
+    }
+  }
+
+  public restart(): void {
+    const folders = vscode.workspace.workspaceFolders;
+    if (this.config.useServer && folders && folders.length) {
+      cp.execSync(`${this.config.command} --restart-server`, {
+        cwd: folders[0].uri.fsPath,
+      });
+    }
+  }
+
+  public stop(): void {
+    const folders = vscode.workspace.workspaceFolders;
+    if (this.config.useServer && folders && folders.length) {
+      cp.execSync(`${this.config.command} --stop-server`, {
+        cwd: folders[0].uri.fsPath,
+      });
     }
   }
 

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -20,6 +20,7 @@ vsStub.workspace.getConfiguration = (
     executePath: '',
     onSave: true,
     useBundler: false,
+    useServer: false,
     suppressRubocopWarnings: false,
   };
 


### PR DESCRIPTION
Since v1.31, RuboCop has provided the server mode which reduces its boot time.  This allows to enable the mode if configured by user.

refs: https://docs.rubocop.org/rubocop/usage/server.html